### PR TITLE
feat: show all-members contributions feed with member filter

### DIFF
--- a/frontend/src/pages/ContributionsPage.tsx
+++ b/frontend/src/pages/ContributionsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { apiService } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import { ContributionModal } from '../components/ContributionModal';
@@ -9,6 +9,10 @@ interface Contribution {
   status: 'pending' | 'verified' | 'rejected';
   createdAt: string;
   reference?: string;
+  user?: {
+    id: string;
+    fullName: string;
+  };
   month?: {
     name: string;
     year: number;
@@ -22,17 +26,18 @@ export const ContributionsPage: React.FC = () => {
   const [showModal, setShowModal] = useState(false);
   const [success, setSuccess] = useState('');
 
+  // Filters
+  const [memberFilter, setMemberFilter] = useState<string>('all');
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+
   useEffect(() => {
     loadData();
   }, []);
 
   const loadData = async () => {
     try {
-      const contributionsData = await apiService.getContributions({ userId: user?.id });
-      setContributions(contributionsData); 
-      if (contributionsData.length > 0) {
-        setSuccess('');
-      }
+      const contributionsData = await apiService.getAllContributions();
+      setContributions(contributionsData);
     } catch (err) {
       console.error('Failed to load data:', err);
     } finally {
@@ -43,8 +48,28 @@ export const ContributionsPage: React.FC = () => {
   const handleContributionSuccess = () => {
     setSuccess('Contribution submitted successfully!');
     loadData();
-    setTimeout(() => setSuccess(''), 5000); // Clear after 5 seconds
+    setTimeout(() => setSuccess(''), 5000);
   };
+
+  // Derive unique members list for the filter dropdown
+  const members = useMemo(() => {
+    const seen = new Map<string, string>();
+    contributions.forEach((c) => {
+      if (c.user && !seen.has(c.user.id)) {
+        seen.set(c.user.id, c.user.fullName);
+      }
+    });
+    return Array.from(seen.entries()).map(([id, fullName]) => ({ id, fullName }));
+  }, [contributions]);
+
+  // Apply filters
+  const filtered = useMemo(() => {
+    return contributions.filter((c) => {
+      const matchesMember = memberFilter === 'all' || c.user?.id === memberFilter;
+      const matchesStatus = statusFilter === 'all' || c.status === statusFilter;
+      return matchesMember && matchesStatus;
+    });
+  }, [contributions, memberFilter, statusFilter]);
 
   if (isLoading) {
     return (
@@ -58,13 +83,12 @@ export const ContributionsPage: React.FC = () => {
     <div className="py-8">
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
         <div>
-          <h1 className="text-3xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent inline-block mb-2">Contributions</h1>
-          <p className="text-slate-500">Track and manage your investments</p>
+          <h1 className="text-3xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent inline-block mb-2">
+            Contributions
+          </h1>
+          <p className="text-slate-500">All member contributions — transparent and up to date</p>
         </div>
-        <button 
-          className="btn-primary" 
-          onClick={() => setShowModal(true)}
-        >
+        <button className="btn-primary" onClick={() => setShowModal(true)}>
           + New Contribution
         </button>
       </div>
@@ -76,37 +100,89 @@ export const ContributionsPage: React.FC = () => {
       )}
 
       <div className="card">
-        <div className="border-b border-slate-100 pb-4 mb-6">
-           <h3 className="text-xl font-bold text-slate-800">History</h3>
+        {/* Header + Filters */}
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-slate-100 pb-4 mb-6">
+          <h3 className="text-xl font-bold text-slate-800">All Contributions</h3>
+          <div className="flex flex-wrap gap-3">
+            {/* Member filter */}
+            <select
+              className="text-sm border border-slate-200 rounded-lg px-3 py-2 text-slate-600 bg-white focus:outline-none focus:ring-2 focus:ring-primary/30 cursor-pointer"
+              value={memberFilter}
+              onChange={(e) => setMemberFilter(e.target.value)}
+            >
+              <option value="all">All Members</option>
+              {user && (
+                <option value={user.id}>My Contributions</option>
+              )}
+              {members
+                .filter((m) => m.id !== user?.id)
+                .map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.fullName}
+                  </option>
+                ))}
+            </select>
+
+            {/* Status filter */}
+            <select
+              className="text-sm border border-slate-200 rounded-lg px-3 py-2 text-slate-600 bg-white focus:outline-none focus:ring-2 focus:ring-primary/30 cursor-pointer"
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+            >
+              <option value="all">All Statuses</option>
+              <option value="pending">Pending</option>
+              <option value="verified">Verified</option>
+              <option value="rejected">Rejected</option>
+            </select>
+          </div>
         </div>
-        
-        {contributions.length === 0 ? (
-           <div className="text-center py-12">
+
+        {filtered.length === 0 ? (
+          <div className="text-center py-12">
             <div className="text-6xl mb-4 opacity-50">📝</div>
-            <p className="text-slate-500 mb-6">No contributions found</p>
-            <button className="btn-primary py-2 px-4 text-sm" onClick={() => setShowModal(true)}>
-              Make your first contribution
-            </button>
+            <p className="text-slate-500 mb-6">
+              {contributions.length === 0
+                ? 'No contributions yet'
+                : 'No contributions match the selected filters'}
+            </p>
+            {contributions.length === 0 && (
+              <button className="btn-primary py-2 px-4 text-sm" onClick={() => setShowModal(true)}>
+                Make your first contribution
+              </button>
+            )}
           </div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-left border-collapse">
               <thead>
                 <tr className="bg-slate-50 border-b border-slate-200">
-                  <th className="p-4 text-xs font-semibold text-slate-500 uppercase tracking-wider">Date</th>
+                  <th className="p-4 text-xs font-semibold text-slate-500 uppercase tracking-wider">Member</th>
                   <th className="p-4 text-xs font-semibold text-slate-500 uppercase tracking-wider">Amount</th>
                   <th className="p-4 text-xs font-semibold text-slate-500 uppercase tracking-wider">Month</th>
                   <th className="p-4 text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
-                  <th className="p-4 text-xs font-semibold text-slate-500 uppercase tracking-wider">Reference</th>
+                  <th className="p-4 text-xs font-semibold text-slate-500 uppercase tracking-wider">Date</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100">
-                {contributions.map((contribution) => (
+                {filtered.map((contribution) => (
                   <tr key={contribution.id} className="hover:bg-slate-50 transition-colors">
-                    <td className="p-4 text-sm text-slate-700">{new Date(contribution.createdAt).toLocaleDateString()}</td>
-                    <td className="p-4 font-mono font-medium text-slate-900">₦{Number(contribution.amount).toLocaleString()}</td>
+                    <td className="p-4">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-slate-800">
+                          {contribution.user?.fullName || 'Unknown'}
+                        </span>
+                        {contribution.user?.id === user?.id && (
+                          <span className="bg-primary/10 text-primary text-[10px] px-2 py-0.5 rounded-full uppercase tracking-wider">
+                            You
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="p-4 font-mono font-medium text-slate-900">
+                      ₦{Number(contribution.amount).toLocaleString()}
+                    </td>
                     <td className="p-4 text-sm text-slate-700">
-                      {contribution.month 
+                      {contribution.month
                         ? `${contribution.month.name} ${contribution.month.year}`
                         : '-'}
                     </td>
@@ -120,7 +196,7 @@ export const ContributionsPage: React.FC = () => {
                       </span>
                     </td>
                     <td className="p-4 text-sm text-slate-500">
-                      {contribution.reference || '-'}
+                      {new Date(contribution.createdAt).toLocaleDateString()}
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/pages/ContributionsPage.tsx
+++ b/frontend/src/pages/ContributionsPage.tsx
@@ -86,7 +86,7 @@ export const ContributionsPage: React.FC = () => {
           <h1 className="text-3xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent inline-block mb-2">
             Contributions
           </h1>
-          <p className="text-slate-500">All member contributions — transparent and up to date</p>
+          <p className="text-slate-500">All member contributions </p>
         </div>
         <button className="btn-primary" onClick={() => setShowModal(true)}>
           + New Contribution

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -31,18 +31,17 @@ export const DashboardPage: React.FC = () => {
 
   const loadDashboardData = async () => {
     try {
-      const [equityData, myEquityData, contributions, allContribsData, monthsData] =
+      const [equityData, myEquityData, allContribsData, monthsData] =
         await Promise.all([
           apiService.getEquity(),
           user ? apiService.getMemberEquity(user.id) : Promise.resolve(null),
-          apiService.getContributions({ userId: user?.id }),
           apiService.getAllContributions(),
           apiService.getMonths(),
         ]);
 
       setEquity(equityData);
       setMyEquity(myEquityData);
-      setRecentContributions(contributions.slice(0, 5));
+      setRecentContributions(allContribsData.slice(0, 10));
       setAllContributions(allContribsData);
       setMonths(monthsData);
     } catch (error) {
@@ -208,15 +207,28 @@ export const DashboardPage: React.FC = () => {
             <div className="flex flex-col gap-3">
               {recentContributions.map((contribution) => (
                 <div key={contribution.id} className="flex justify-between items-center p-4 bg-slate-50/50 rounded-lg hover:bg-slate-50 transition-colors border border-transparent hover:border-slate-100">
-                  <div>
-                    <div className="font-semibold text-slate-800 mb-1">
-                      ₦{Number(contribution.amount).toLocaleString()}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="font-semibold text-slate-800">
+                        {contribution.user?.fullName || 'Unknown'}
+                      </span>
+                      {contribution.user?.id === user?.id && (
+                        <span className="bg-primary/10 text-primary text-[10px] px-2 py-0.5 rounded-full uppercase tracking-wider">You</span>
+                      )}
                     </div>
-                    <div className="text-xs text-slate-400">
-                      {new Date(contribution.createdAt).toLocaleDateString()}
+                    <div className="flex items-center gap-2 text-xs text-slate-400">
+                      <span className="font-mono font-medium text-slate-600">
+                        ₦{Number(contribution.amount).toLocaleString()}
+                      </span>
+                      <span>·</span>
+                      <span>
+                        {contribution.month
+                          ? `${contribution.month.name} ${contribution.month.year}`
+                          : new Date(contribution.createdAt).toLocaleDateString()}
+                      </span>
                     </div>
                   </div>
-                  <span className={`badge ${
+                  <span className={`badge ml-3 shrink-0 ${
                     contribution.status === 'verified' ? 'bg-green-100 text-green-700' :
                     contribution.status === 'pending' ? 'bg-amber-100 text-amber-700' :
                     'bg-red-100 text-red-700'


### PR DESCRIPTION
- Dashboard 'Recent Contributions' now displays the 10 most recent contributions across all members (previously showed only the current user's last 5). Each row shows member name, amount, month/period, and a verified/pending/rejected status badge with a 'You' pill for the current user's own entries.

- Contributions page upgraded to an all-members table with a Member column and two filter dropdowns (Member + Status). 'My Contributions' is pinned at the top of the member filter for quick personal history access. Fetches via getAllContributions() so no userId filter is sent.